### PR TITLE
Add Etcd Cluster Health  for Yoda Proxy

### DIFF
--- a/bin/supervisord-wrapper.sh
+++ b/bin/supervisord-wrapper.sh
@@ -5,6 +5,7 @@ HOST_IP="${HOST_IP:-127.0.0.1}"
 cat <<END>> /etc/profile.d/cluster-deployer-env.sh
 export HOST_IP='${HOST_IP}'
 export ETCD_URL='${ETCD_URL:-${HOST_IP}:4001}'
+export ETCDCTL="${ETCDCTL:-etcdctl --peers $ETCD_URL}"
 export ETCD_PROXY_BASE='${ETCD_PROXY_BASE:-/yoda}'
 export PROXY_HOST='${PROXY_HOST:-yoda.local.sh}'
 export SYNC_CERTS='${SYNC_CERTS:-false}'
@@ -18,5 +19,6 @@ if [ ! -e /dev/log ]; then
   service rsyslog start
 fi
 
+$ETCDCTL cluster-health
 
 /bin/bash -le -c "/usr/local/bin/supervisord -c /etc/supervisor/supervisord.conf"


### PR DESCRIPTION
Add Etcd Cluster Health  for Yoda Proxy. This will prevent yoda proxy from starting if etcd is unhealthy.